### PR TITLE
SwaggerのResponseの修正

### DIFF
--- a/src/content/content.controller.ts
+++ b/src/content/content.controller.ts
@@ -1,4 +1,10 @@
-import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiExtraModels,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import {
   Controller,
   Get,
@@ -15,18 +21,29 @@ import { CreateContentDTO, UpdateContentDTO } from './content.dto';
 import { Content } from '../entities/content.entity';
 
 @ApiTags('Content')
+@ApiExtraModels(Content)
 @Controller('content')
 export class ContentController {
   constructor(private readonly service: ContentService) {}
 
   @Get()
   @ApiOperation({ summary: 'コンテンツ一覧の取得' })
+  @ApiResponse({
+    status: 200,
+    description: 'コンテンツ一覧を取得します',
+    type: [Content],
+  })
   async getAllContentList(): Promise<Content[]> {
     return await this.service.findAll();
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'コンテンツの取得' })
+  @ApiResponse({
+    status: 200,
+    description: '指定されたIDのコンテンツを取得します',
+    type: Content,
+  })
   async getContent(@Param('id') id: number): Promise<Content> {
     const res = await this.service.findOne(id);
     if (res === undefined) throw new BadRequestException();
@@ -36,6 +53,11 @@ export class ContentController {
   @Post()
   @ApiOperation({ summary: 'コンテンツの作成' })
   @ApiBody({ type: CreateContentDTO })
+  @ApiResponse({
+    status: 201,
+    description: '新しいコンテンツが作成されました',
+    type: Content,
+  })
   async addContent(@Body() content: CreateContentDTO) {
     return await this.service.create(content);
   }
@@ -43,6 +65,11 @@ export class ContentController {
   @Put(':id')
   @ApiOperation({ summary: 'コンテンツの更新' })
   @ApiBody({ type: UpdateContentDTO })
+  @ApiResponse({
+    status: 200,
+    description: 'コンテンツが更新されました',
+    type: Content,
+  })
   async updateContent(
     @Param('id') id: number,
     @Body() content: UpdateContentDTO,
@@ -55,6 +82,10 @@ export class ContentController {
   @Delete(':id')
   @HttpCode(204)
   @ApiOperation({ summary: 'コンテンツの削除' })
+  @ApiResponse({
+    status: 204,
+    description: 'コンテンツが削除されました',
+  })
   async deleteContent(@Param('id') id: number) {
     const res = await this.service.delete(id);
     if (res == null) throw new BadRequestException();

--- a/src/entities/content.entity.ts
+++ b/src/entities/content.entity.ts
@@ -5,21 +5,44 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
 
 @Entity()
 export class Content {
+  @ApiProperty({
+    description: 'コンテンツのID',
+    example: 1,
+  })
   @PrimaryGeneratedColumn()
   readonly id: number;
 
+  @ApiProperty({
+    description: 'コンテンツのタイトル',
+    example: 'Hello Title',
+    nullable: true,
+  })
   @Column('varchar', { length: 100, nullable: true })
   title?: string;
 
+  @ApiProperty({
+    description: 'コンテンツの本文',
+    example: 'Hello Body',
+    nullable: true,
+  })
   @Column('varchar', { length: 2000, nullable: true })
   body?: string;
 
+  @ApiProperty({
+    description: '作成日時',
+    example: '2025-04-04T00:00:00.000Z',
+  })
   @CreateDateColumn()
   readonly createdAt?: Date;
 
+  @ApiProperty({
+    description: '更新日時',
+    example: '2025-04-04T00:00:00.000Z',
+  })
   @UpdateDateColumn()
   readonly updatedAt?: Date;
 }


### PR DESCRIPTION
<!-- GitHub Copilot への依頼事項 :コードレビューを実施してコメントをする際は日本語でお願いします。 -->

#32 からBranchを切っていますので、そちらからマージをお願いいたします

## issue <!-- #issue番号を記載してください -->

Swaggerを見ていて、APIのResponseのExample Bodyが表示されていなく、少し不便だと感じたため、そちらの修正です

<img width="1084" alt="スクリーンショット 2025-04-07 9 08 50" src="https://github.com/user-attachments/assets/e1735315-d668-477b-aaa7-e6c73cb1a28d" />


## 変更内容 <!-- 行った変更を簡略に記載してください -->

## 確認したこと <!-- 何を以て変更要件を満たしていると判断したかを記載してください -->

- [x] Response BodyをSwaggerから確認できること

## スクリーンショット <!--  変更がわかる画面があれば記載してください -->

<img width="1066" alt="スクリーンショット 2025-04-07 9 08 09" src="https://github.com/user-attachments/assets/846dae68-bcfe-4f9c-8407-e9df19f54a37" />


## 補足事項 <!-- 補足で説明が必要な場合記載してください -->

## PR時のセルフチェック <!-- PRのセルフチェックをしてください -->
- [ ] 関数や変数の命名は一目で分かるものになってますか？
- [ ] コメントは適切な量で、誰が見ても分かるコメントになってますか？
- [ ] PR内容に関するテストは書きましたか？
- [ ] PR内容に付随する各種ドキュメントは一緒に修正しましたか？
- [ ] Issue の完了の定義は満たせていますか？
